### PR TITLE
Add the ability to filter based on after_id

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 Rails/InverseOf:
   Enabled: false
+Rails/ActiveRecordAliases:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
 
 Metrics/BlockLength:
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-APP_RAKEFILE = File.expand_path('../spec/dummy/Rakefile', __FILE__)
+APP_RAKEFILE = File.expand_path('spec/dummy/Rakefile', __dir__)
 load 'rails/tasks/engine.rake'
 
 load 'rails/tasks/statistics.rake'

--- a/app/queries/bragi/item_index_query.rb
+++ b/app/queries/bragi/item_index_query.rb
@@ -18,6 +18,7 @@ module Bragi
     def query
       @relation.page(page_number).per(page_size)
                .where(where_clause)
+               .where(after_id_filter)
                .order('-position DESC').order(finished: :asc) # Special MySQL syntax to get the nulls last
     end
 
@@ -42,6 +43,13 @@ module Bragi
 
     def audio_identifier_filter
       @params.dig(:filter, :audio_identifier)
+    end
+
+    def after_id_filter
+      after_id = @params.dig(:filter, :after_id)
+      return nil unless after_id
+      starting_item = Item.find_by! id: after_id
+      "position > #{starting_item.position}"
     end
 
     def page_size

--- a/bragi.gemspec
+++ b/bragi.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 # Maintain your gem's version:
 require 'bragi/version'

--- a/lib/bragi/version.rb
+++ b/lib/bragi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bragi
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../dummy/config/environment', __FILE__)
+require File.expand_path('dummy/config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'

--- a/spec/requests/bragi/items_api_spec.rb
+++ b/spec/requests/bragi/items_api_spec.rb
@@ -132,7 +132,7 @@ module Bragi
         let!(:item2) { create :bragi_played_item, user: user, finished: '2017-01-01T00:04:00Z' }
         let!(:item3) { create :bragi_played_item, user: user, finished: '2017-01-01T00:03:00Z' }
         let!(:item4) { create :bragi_played_item, user: user, finished: '2017-01-01T00:00:00Z' }
-        let!(:item5) { create :bragi_item, user: user, position: 2 }
+        let!(:item5) { create :bragi_item, user: user, position: 2, status: 'playing' }
         let!(:item6) { create :bragi_item, user: user, position: 1 }
         let!(:item7) { create :bragi_item, user: user, position: 4 }
 
@@ -149,6 +149,36 @@ module Bragi
           expect(json['data'][4]['id']).to eq item4.id.to_s
           expect(json['data'][5]['id']).to eq item3.id.to_s
           expect(json['data'][6]['id']).to eq item2.id.to_s
+        end
+
+        it 'fetches by after_id' do
+          get '/items', params: { filter: { after_id: item6.id } }, headers: { 'Authorization' => 'authorized_user' }
+
+          expect(response).to have_http_status(200)
+          json = JSON.parse response.body
+          expect(json['data'].size).to eq 3
+          json['data'].each do |item|
+            expect(item['attributes']['status']).to be_in(%w[unplayed playing])
+          end
+        end
+
+        it 'fetches by after_id and status' do
+          get '/items', params: { filter: { after_id: item6.id, status: 'unplayed' } }, headers: { 'Authorization' => 'authorized_user' }
+
+          expect(response).to have_http_status(200)
+          json = JSON.parse response.body
+          expect(json['data'].size).to eq 2
+          json['data'].each do |item|
+            expect(item['attributes']['status']).to eq 'unplayed'
+          end
+        end
+
+        it 'returns no items if after_id is last item' do
+          get '/items', params: { filter: { after_id: item7.id } }, headers: { 'Authorization' => 'authorized_user' }
+
+          expect(response).to have_http_status(200)
+          json = JSON.parse response.body
+          expect(json['data'].size).to eq 0
         end
       end
 

--- a/spec/requests/bragi/items_api_spec.rb
+++ b/spec/requests/bragi/items_api_spec.rb
@@ -157,9 +157,9 @@ module Bragi
           expect(response).to have_http_status(200)
           json = JSON.parse response.body
           expect(json['data'].size).to eq 3
-          json['data'].each do |item|
-            expect(item['attributes']['status']).to be_in(%w[unplayed playing])
-          end
+          expect(json['data'][0]['id']).to eq item5.id.to_s
+          expect(json['data'][1]['id']).to eq item1.id.to_s
+          expect(json['data'][2]['id']).to eq item7.id.to_s
         end
 
         it 'fetches by after_id and status' do
@@ -168,9 +168,8 @@ module Bragi
           expect(response).to have_http_status(200)
           json = JSON.parse response.body
           expect(json['data'].size).to eq 2
-          json['data'].each do |item|
-            expect(item['attributes']['status']).to eq 'unplayed'
-          end
+          expect(json['data'][0]['id']).to eq item1.id.to_s
+          expect(json['data'][1]['id']).to eq item7.id.to_s
         end
 
         it 'returns no items if after_id is last item' do


### PR DESCRIPTION
This is a feature which allows users to limit the items returned by the API to those after the item specified by the `after_id` filter option.